### PR TITLE
Prevent deletion of category when in use

### DIFF
--- a/api/src/modules/categories/category.controller.ts
+++ b/api/src/modules/categories/category.controller.ts
@@ -32,6 +32,6 @@ export const remove: RequestHandler = async (req, res) => {
 };
 
 export const usage: RequestHandler = async (req, res) => {
-  const count = getCategoryCount(req.userId!, req.params.id);
+  const count = await getCategoryCount(req.userId!, req.params.id);
   res.json({ count });
 };

--- a/api/src/modules/categories/category.controller.ts
+++ b/api/src/modules/categories/category.controller.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from 'express';
 import {
   createCategory,
   deleteCategory,
+  getCategoryCount,
   listCategories,
   renameCategory,
 } from './category.service';
@@ -28,4 +29,9 @@ export const rename: RequestHandler = async (req, res) => {
 export const remove: RequestHandler = async (req, res) => {
   await deleteCategory(req.userId!, req.params.id);
   res.status(204).send();
+};
+
+export const usage: RequestHandler = async (req, res) => {
+  const count = getCategoryCount(req.userId!, req.params.id);
+  res.json({ count });
 };

--- a/api/src/modules/categories/category.route.ts
+++ b/api/src/modules/categories/category.route.ts
@@ -6,11 +6,16 @@ import {
   categoryIdParam,
   categoryRenameSchema,
 } from './category.schema';
-import { create, list, remove, rename } from './category.controller';
+import { create, list, remove, rename, usage } from './category.controller';
 
 export const categoryRouter = Router();
 
 categoryRouter.get('/', asyncHandler(list));
+categoryRouter.get(
+  '/:id/usage',
+  validate(categoryIdParam, 'params'),
+  asyncHandler(usage)
+);
 categoryRouter.post(
   '/',
   validate(categoryCreateSchema, 'body'),

--- a/api/src/modules/categories/category.service.ts
+++ b/api/src/modules/categories/category.service.ts
@@ -44,12 +44,17 @@ export async function renameCategory(userId: string, id: string, name: string) {
 }
 
 export async function deleteCategory(userId: string, id: string) {
+  const owned = await prisma.category.findUnique({
+    where: { id, userId },
+    select: { id: true },
+  });
+  if (!owned) throw new HttpError(404, 'Category not found');
   const usage = await prisma.expense.count({
     where: { userId, categoryId: id },
   });
 
   if (usage > 0) {
-    throw new HttpError(400, 'in use');
+    throw new HttpError(409, `Category is in use by ${usage} expense(s)`);
   }
 
   await prisma.category.delete({ where: { id } });
@@ -57,7 +62,7 @@ export async function deleteCategory(userId: string, id: string) {
 
 export async function getCategoryCount(userId: string, id: string) {
   const count = await prisma.expense.count({
-    where: { categoryId: id },
+    where: { userId, categoryId: id },
   });
   return count;
 }

--- a/api/src/modules/categories/category.service.ts
+++ b/api/src/modules/categories/category.service.ts
@@ -26,7 +26,7 @@ export async function createCategory(userId: string, name: string) {
 }
 
 export async function renameCategory(userId: string, id: string, name: string) {
-  const owned = await prisma.category.findUnique({ where: { id, userId } });
+  const owned = await prisma.category.findFirst({ where: { id, userId } });
   if (!owned) throw new HttpError(404, 'Category not found');
   try {
     return await prisma.category.update({
@@ -44,14 +44,12 @@ export async function renameCategory(userId: string, id: string, name: string) {
 }
 
 export async function deleteCategory(userId: string, id: string) {
-  const owned = await prisma.category.findUnique({
+  const owned = await prisma.category.findFirst({
     where: { id, userId },
     select: { id: true },
   });
   if (!owned) throw new HttpError(404, 'Category not found');
-  const usage = await prisma.expense.count({
-    where: { userId, categoryId: id },
-  });
+  const usage = await getCategoryCount(userId, id);
 
   if (usage > 0) {
     throw new HttpError(409, `Category is in use by ${usage} expense(s)`);

--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -81,6 +81,12 @@ export default function CategoriesPage() {
       toast.error(e instanceof Error ? e.message : 'Failed to delete category'),
   });
 
+  const usage = useQuery({
+    queryKey: ['category-usage', deleteId],
+    queryFn: () => api<{ count: number }>(`/categories/${deleteId}/usages`),
+    enabled: !!deleteId, // only fetch when dialog is open with a target
+  });
+
   return (
     <main className="space-y-6">
       <Card>
@@ -171,10 +177,17 @@ export default function CategoriesPage() {
                         <DialogHeader>
                           <DialogTitle>Delete “{c.name}”?</DialogTitle>
                         </DialogHeader>
-                        <p className="text-sm text-muted-foreground">
-                          This will detach it from any expenses and remove the
-                          category.
-                        </p>
+                        {usage.isSuccess && usage.data.count > 0 && (
+                          <p className="text-sm text-destructive">
+                            Cannot delete: this category is used by
+                            {' ' + usage.data.count} expense(s).
+                          </p>
+                        )}
+                        {usage.isSuccess && usage.data.count === 0 && (
+                          <p className="text-sm text-muted-foreground">
+                            This action cannot be undone.
+                          </p>
+                        )}
                         <DialogFooter className="mt-4">
                           <Button
                             variant="ghost"
@@ -185,7 +198,7 @@ export default function CategoriesPage() {
                           <Button
                             variant="destructive"
                             onClick={() => del.mutate()}
-                            disabled={del.isPending}
+                            disabled={del.isPending || usage.isLoading}
                           >
                             Delete
                           </Button>

--- a/frontend/src/app/app/categories/page.tsx
+++ b/frontend/src/app/app/categories/page.tsx
@@ -83,7 +83,7 @@ export default function CategoriesPage() {
 
   const usage = useQuery({
     queryKey: ['category-usage', deleteId],
-    queryFn: () => api<{ count: number }>(`/categories/${deleteId}/usages`),
+    queryFn: () => api<{ count: number }>(`/categories/${deleteId}/usage`),
     enabled: !!deleteId, // only fetch when dialog is open with a target
   });
 
@@ -198,7 +198,11 @@ export default function CategoriesPage() {
                           <Button
                             variant="destructive"
                             onClick={() => del.mutate()}
-                            disabled={del.isPending || usage.isLoading}
+                            disabled={
+                              del.isPending ||
+                              usage.isLoading ||
+                              (usage.isSuccess && usage.data.count > 0)
+                            }
                           >
                             Delete
                           </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shows how many expenses reference a category before deletion.

- **API**
  - Added an endpoint to fetch a category's usage/count.

- **Behavior**
  - Delete dialog displays dynamic messaging (cannot delete if in use; otherwise warns action is irreversible).
  - Delete action is disabled while usage is loading and blocked when usage > 0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->